### PR TITLE
#46 - Update LazySets

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,9 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SCS = "c946c3f1-0d1f-5ce8-9dea-7daa1f7e2d13"
 
+[compat]
+LazySets = "1.27.0"
+
 [extras]
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SCS = "c946c3f1-0d1f-5ce8-9dea-7daa1f7e2d13"
 
 [compat]
-LazySets = "1.27.0"
+LazySets = "1.29.0"
 
 [extras]
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"

--- a/src/NeuralVerification.jl
+++ b/src/NeuralVerification.jl
@@ -11,7 +11,7 @@ using LinearAlgebra
 using Parameters
 using Interpolations # only for PiecewiseLinear
 
-import LazySets: dim, HalfSpace # necessary to avoid conflict with Polyhedra
+import LazySets: dim, HalfSpace, translate # necessary to avoid conflict with Polyhedra
 
 using Requires
 

--- a/src/NeuralVerification.jl
+++ b/src/NeuralVerification.jl
@@ -11,7 +11,7 @@ using LinearAlgebra
 using Parameters
 using Interpolations # only for PiecewiseLinear
 
-import LazySets: dim, HalfSpace, translate # necessary to avoid conflict with Polyhedra
+import LazySets: dim, HalfSpace, affine_map # necessary to avoid conflict with Polyhedra
 
 using Requires
 

--- a/src/utils/util.jl
+++ b/src/utils/util.jl
@@ -306,8 +306,8 @@ Return:
 affine_map(layer::Layer, input::AbstractVector) = layer.weights*input + layer.bias
 function affine_map(layer::Layer, input::AbstractPolytope)
     W, b = layer.weights, layer.bias
-    P = linear_map(W, input, algorithm="vrep")
-    return convert(HPolytope, translate(P, b))
+    P = affine_map(W, input, b)
+    return convert(HPolytope, P)
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,10 @@
 using NeuralVerification, LazySets, GLPKMathProgInterface
 using Test
 
+# comment to re-enable assertion checks
+LazySets.deactivate_assertions()
+LazySets.Assertions.deactivate_assertions(NeuralVerification)
+
 import NeuralVerification: ReLU, Id
 
 macro no_error(ex)


### PR DESCRIPTION
This PR has two purposes:

- Bump the package to use the latest released version of LazySets. The tests in NeuralVerification now pass, but see (*).
- Cleanup of the concrete affine map functions, using those provided from LazySets directly (see [this thread](https://github.com/sisl/NeuralVerification.jl/issues/46)).

(*) To make the tests pass, I have deactivated assertions (I don't recommend to keep this behavior.. but for the purpose of debugging it's useful to have!), see the new lines in `runtests.jl`. With assertions activated, I get the error reported here https://github.com/sisl/NeuralVerification.jl/issues/83.