### PR TITLE
Avoid model recreation at every call of reluplex_step

### DIFF
--- a/src/satisfiability/reluplex.jl
+++ b/src/satisfiability/reluplex.jl
@@ -119,14 +119,13 @@ function reluplex_step(solver::Reluplex,
 
         for repair! in (type_one_repair!, type_two_repair!)
             # Add the constraints associated with the ReLU being fixed
-            con_one, con_two = repair!(model, ẑ[i][j], z[i][j])
+            new_constraints = repair!(model, ẑ[i][j], z[i][j])
 
             # Recurse with the ReLU i, j fixed to active or inactive
             result = reluplex_step(solver, problem, model, ẑ, z, relu_status)
 
             # Reset the model when we're done with this ReLU
-            delete(model, con_one)
-            delete(model, con_two)
+            delete.(model, new_constraints)
 
             result.status == :violated && return result
         end

--- a/src/satisfiability/reluplex.jl
+++ b/src/satisfiability/reluplex.jl
@@ -54,14 +54,14 @@ type_two_broken(ẑᵢⱼ, zᵢⱼ) = (zᵢⱼ == 0.0) && (ẑᵢⱼ > 0.0)
 
 # Corresponds to a ReLU that shouldn't be active but is
 function type_one_repair!(model, ẑᵢⱼ, zᵢⱼ)
-    @constraint(model, con_one, ẑᵢⱼ == zᵢⱼ)
-    @constraint(model, con_two, ẑᵢⱼ >= 0.0)
+    con_one = @constraint(model, ẑᵢⱼ == zᵢⱼ)
+    con_two = @constraint(model, ẑᵢⱼ >= 0.0)
     return con_one, con_two
 end
 # Corresponds to a ReLU that should be active but isn't
 function type_two_repair!(model, ẑᵢⱼ, zᵢⱼ)
-    @constraint(model, con_one, ẑᵢⱼ <= 0.0)
-    @constraint(model, con_two, zᵢⱼ == 0.0)
+    con_one = @constraint(model, ẑᵢⱼ <= 0.0)
+    con_two = @constraint(model, zᵢⱼ == 0.0)
     return con_one, con_two
 end
 
@@ -91,25 +91,12 @@ function encode(solver::Reluplex, model::Model,  problem::Problem)
     bounds = get_bounds(problem)
     for (i, L) in enumerate(layers)
         @constraint(model, affine_map(L, z[i]) .== ẑ[i+1])
-        add_set_constraint!(model, bounds[i], ẑ[i])
+        add_set_constraint!(model, bounds[i], z[i])
         activation_constraint!(model, ẑ[i+1], z[i+1], L.activation)
     end
     add_complementary_set_constraint!(model, problem.output, last(z))
     feasibility_problem!(model)
     return ẑ, z
-end
-
-function enforce_repairs!(model::Model, ẑ, z, relu_status)
-    # Need to decide what to do with last layer, this assumes there is no ReLU.
-    for i in 1:length(relu_status), j in 1:length(relu_status[i])
-        ẑᵢⱼ = ẑ[i][j]
-        zᵢⱼ = z[i][j]
-        if relu_status[i][j] == 1
-            type_one_repair!(model, ẑᵢⱼ, zᵢⱼ)
-        elseif relu_status[i][j] == 2
-            type_two_repair!(model, ẑᵢⱼ, zᵢⱼ)
-        end
-    end
 end
 
 function reluplex_step(solver::Reluplex,
@@ -131,8 +118,7 @@ function reluplex_step(solver::Reluplex,
         i == 0 && return CounterExampleResult(:violated, value.(first(ẑ)))
 
         for repair_type in 1:2
-            # Set the relu status to the current fix.
-            relu_status[i][j] = repair_type
+            # Add the constraints associated with
             if (repair_type == 1)
                 con_one, con_two = type_one_repair!(model, ẑ[i][j], z[i][j])
             else

--- a/src/satisfiability/reluplex.jl
+++ b/src/satisfiability/reluplex.jl
@@ -89,9 +89,12 @@ function encode(solver::Reluplex, model::Model,  problem::Problem)
     bounds = get_bounds(problem)
     for (i, L) in enumerate(layers)
         @constraint(model, affine_map(L, z[i]) .== ẑ[i+1])
-        add_set_constraint!(model, bounds[i], ẑ[i])
+        add_set_constraint!(model, bounds[i], z[i])
         activation_constraint!(model, ẑ[i+1], z[i+1], L.activation)
     end
+    # Add the bounds on your output layer
+    add_set_constraint!(model, last(bounds), last(z))
+    # Add the complementary set defind as part of the problem
     add_complementary_set_constraint!(model, problem.output, last(z))
     feasibility_problem!(model)
     return ẑ, z

--- a/src/satisfiability/reluplex.jl
+++ b/src/satisfiability/reluplex.jl
@@ -91,7 +91,7 @@ function encode(solver::Reluplex, model::Model,  problem::Problem)
     bounds = get_bounds(problem)
     for (i, L) in enumerate(layers)
         @constraint(model, affine_map(L, z[i]) .== ẑ[i+1])
-        add_set_constraint!(model, bounds[i], z[i])
+        add_set_constraint!(model, bounds[i], ẑ[i])
         activation_constraint!(model, ẑ[i+1], z[i+1], L.activation)
     end
     add_complementary_set_constraint!(model, problem.output, last(z))

--- a/src/satisfiability/reluplex.jl
+++ b/src/satisfiability/reluplex.jl
@@ -117,19 +117,14 @@ function reluplex_step(solver::Reluplex,
         # In case no broken relus could be found, return the "input" as a counterexample
         i == 0 && return CounterExampleResult(:violated, value.(first(ẑ)))
 
-        for repair_type in 1:2
-            # Add the constraints associated with
-            if (repair_type == 1)
-                con_one, con_two = type_one_repair!(model, ẑ[i][j], z[i][j])
-            else
-                con_one, con_two = type_two_repair!(model, ẑ[i][j], z[i][j])
-            end
+        for repair! in (type_one_repair!, type_two_repair!)
+            # Add the constraints associated with the ReLU being fixed
+            con_one, con_two = repair!(model, ẑ[i][j], z[i][j])
 
             # Recurse with the ReLU i, j fixed to active or inactive
             result = reluplex_step(solver, problem, model, ẑ, z, relu_status)
 
-            # Reset the relu (and our model) when we're done with it.
-            relu_status[i][j] = 0
+            # Reset the model when we're done with this ReLU
             delete(model, con_one)
             delete(model, con_two)
 

--- a/src/satisfiability/reluplex.jl
+++ b/src/satisfiability/reluplex.jl
@@ -94,7 +94,6 @@ function encode(solver::Reluplex, model::Model,  problem::Problem)
         add_set_constraint!(model, bounds[i], ẑ[i])
         activation_constraint!(model, ẑ[i+1], z[i+1], L.activation)
     end
-
     add_complementary_set_constraint!(model, problem.output, last(z))
     feasibility_problem!(model)
     return ẑ, z

--- a/src/satisfiability/reluplex.jl
+++ b/src/satisfiability/reluplex.jl
@@ -91,12 +91,10 @@ function encode(solver::Reluplex, model::Model,  problem::Problem)
     bounds = get_bounds(problem)
     for (i, L) in enumerate(layers)
         @constraint(model, affine_map(L, z[i]) .== ẑ[i+1])
-        add_set_constraint!(model, bounds[i], z[i])
+        add_set_constraint!(model, bounds[i], ẑ[i])
         activation_constraint!(model, ẑ[i+1], z[i+1], L.activation)
     end
-    # Add the bounds on your output layer
-    add_set_constraint!(model, last(bounds), last(z))
-    # Add the complementary set defind as part of the problem
+
     add_complementary_set_constraint!(model, problem.output, last(z))
     feasibility_problem!(model)
     return ẑ, z

--- a/src/satisfiability/reluplex.jl
+++ b/src/satisfiability/reluplex.jl
@@ -135,10 +135,8 @@ function reluplex_step(solver::Reluplex,
             relu_status[i][j] = repair_type
             if (repair_type == 1)
                 con_one, con_two = type_one_repair!(model, ẑ[i][j], z[i][j])
-                print("Con one, two: ", con_one, con_two)
             else
                 con_one, con_two = type_two_repair!(model, ẑ[i][j], z[i][j])
-                print("Con one, two: ", con_one, con_two)
             end
 
             # Recurse with the ReLU i, j fixed to active or inactive


### PR DESCRIPTION
Currently, the model is recreated whenever a ReLU is fixed. This changes it so that (1) the desired constraints are added to the model to fix the ReLU to be active or inactive, (2) the recursive call is made, then (3) the constraints are removed from the model. This is now possible b/c of added functionality to the JuMP optimization library.