### PR TITLE
Nodes

### DIFF
--- a/src/reachability/maxSens.jl
+++ b/src/reachability/maxSens.jl
@@ -40,24 +40,19 @@ end
 
 # This function is called by forward_network
 function forward_layer(solver::MaxSens, L::Layer, input::Hyperrectangle)
-    (W, b, act) = (L.weights, L.bias, L.activation)
-    c, r = center(input), radius_hyperrectangle(input)
-
-    output = W * c + b
-    deviation = abs.(W) * r
-
-    β = @. act(output)
-    βmax = @. act(output + deviation)
-    βmin = @. act(output - deviation)
+    output = approximate_affine_map(L,  input)
+    β    = L.activation.(output.center)
+    βmax = L.activation.(high(output))
+    βmin = L.activation.(low(output))
 
     if solver.tight
         center = (βmax + βmin)/2
-        gamma =  (βmax - βmin)/2
+        rad =  (βmax - βmin)/2
     else
         center = β
-        gamma = @. max(abs(βmax - β), abs(βmin - β))
+        rad = @. max(abs(βmax - β), abs(βmin - β))
     end
-    return Hyperrectangle(center, gamma)
+    return Hyperrectangle(center, rad)
 end
 
 

--- a/src/utils/network.jl
+++ b/src/utils/network.jl
@@ -1,19 +1,4 @@
 """
-    Node{N, F}
-
-A single node in a layer.
-### Fields
- - `w::Vector{N}`
- - `b::N`
- - `activation::F`
-"""
-struct Node{F<:ActivationFunction, N<:Number}
-    w::Vector{N}
-    b::N
-    act::F
-end
-
-"""
     Layer{F, N}
 
 Consists of `weights` and `bias` for linear mapping, and `activation` for nonlinear mapping.


### PR DESCRIPTION
Noticed in #105 that `Node` really isn't required for maxsens. 
It also should be quite possible to write it using our own `approximate_affine_map` or LazySet's `overapproximate` (probably). For example, we can write it as 
```julia 
function forward_layer(solver::MaxSens, L::Layer, input::Hyperrectangle)
    output = approximate_affine_map(L,  input)
    β = L.activation.(center(output))
    βmax = L.activation.(high(output)
    βmin = L.activation.(low(deviation))
    #etc.
```