### PR TITLE
ConvDual fix to store input_ReLU for all layers

### DIFF
--- a/src/optimization/convDual.jl
+++ b/src/optimization/convDual.jl
@@ -84,7 +84,6 @@ function get_bounds(nnet::Network, input::Vector{Float64}, ϵ::Float64)
     μ = Vector{Vector{Vector{Float64}}}()
     input_ReLU = Vector{Vector{Float64}}()
 
-
     v1 = layers[1].weights'
     push!(γ, layers[1].bias)
     # Bounds for the first layer
@@ -105,7 +104,7 @@ function get_bounds(nnet::Network, input::Vector{Float64}, ϵ::Float64)
         v1 = v1 * WD' # TODO CHECK
         map!(g -> WD*g,   γ, γ)
 
-        # Updating ν_j
+        # Updating ν_j for all previous layers
         for M in μ
             map!(m -> WD*m,   M, M)
         end
@@ -135,8 +134,7 @@ function all_neg_pos_sums(slopes, l, μ, n_output)
         for (j, M) in enumerate(μ[i])         # M::Vector{Float64}
             if 0 < slopes[i][j] < 1              # if in the triangle region of relaxed ReLU
                 #posind = M .> 0
-                M = μ[i][j]
-                neg .+= ℓ[j] * min.(-M, 0) #-M .* !posind  # multiply by boolean to set the undesired values to 0.0
+                neg .+= ℓ[j] * min.(M, 0) #-M .* !posind  # multiply by boolean to set the undesired values to 0.0
                 pos .+= ℓ[j] * max.(M, 0) #M .* posind
             end
         end

--- a/src/optimization/convDual.jl
+++ b/src/optimization/convDual.jl
@@ -111,6 +111,10 @@ function get_bounds(nnet::Network, input::Vector{Float64}, ϵ::Float64)
         # Compute bounds
         ψ = v1' * input + sum(γ)
         eps_v1_sum = ϵ * vec(sum(abs, v1, dims = 1))
+        println("Num output: ", n_output)
+        println("mu: ", μ)
+        println("Length mu: ", length(μ))
+        println("Slopes: ", input_ReLU)
         neg, pos = all_neg_pos_sums(input_ReLU, l, μ, n_output)
         push!(l,  ψ - eps_v1_sum + neg )
         push!(u,  ψ + eps_v1_sum - pos )
@@ -126,6 +130,7 @@ function all_neg_pos_sums(slopes, l, μ, n_output)
     pos = zeros(n_output)
     # Need to debug
     for (i, ℓ) in enumerate(l)                # ℓ::Vector{Float64}
+        println("Mu[i] size: ", size(μ[i]))
         for (j, M) in enumerate(μ[i])         # M::Vector{Float64}
             if 0 < slopes[j] < 1              # if in the triangle region of relaxed ReLU
                 #posind = M .> 0


### PR DESCRIPTION
The bound propagation used in ConvDual needs access to the input_ReLU values (slopes of the triangle relaxation of the ReLU) for all previous layers. However, it was only storing the most recent layer and then would result in indexing errors during bound computation.

Addresses issue #108 