### PR TITLE
Fix iLP #149

### DIFF
--- a/src/optimization/iLP.jl
+++ b/src/optimization/iLP.jl
@@ -63,10 +63,12 @@ function solve(solver::ILP, problem::Problem)
 end
 
 function interpret_result(solver::ILP, x, input)
-    if prod(abs.(x - input.center) .>= input.radius)
-        return AdversarialResult(:holds, minimum(abs.(x - input.center)))
+    radius = abs.(x .- center(input))
+
+    if all(radius .>= radius_hyperrectangle(input))
+        return AdversarialResult(:holds, minimum(radius))
     else
-        return AdversarialResult(:violated, minimum(abs.(x - input.center)))
+        return AdversarialResult(:violated, minimum(radius))
     end
 end
 

--- a/src/optimization/mipVerify.jl
+++ b/src/optimization/mipVerify.jl
@@ -43,9 +43,5 @@ function solve(solver::MIPVerify, problem::Problem)
     if termination_status(model) == INFEASIBLE
         return AdversarialResult(:holds)
     end
-    if value(o) >= maximum(problem.input.radius)
-        return AdversarialResult(:holds)
-    else
-        return AdversarialResult(:violated, value(o))
-    end
+    return AdversarialResult(:violated, value(o))
 end


### PR DESCRIPTION
iLP only checks one linear branch of the network that has the same activation as the center of the input set. Hence it should return false for any input set that goes beyond one linear branch.

Now instead of comparing the maximum allowable disturbance with the maximum input radius (scalar to scalar comparison), we check the possible deviation in every dimension (vector to vector comparison). If in either dimension, the input radius is greater than the allowable disturbance in that dimension, we will return a :violation.

This pull request also simplifies MIPVerify. Since we directly encode the input constraints in the problem, it is not possible for the maximum allowable disturbance to be greater than the maximum input radius. Hence if there is a solution to the optimization problem, then the solution must be a counter example. In this way, MIPVerify is sound and complete.