### PR TITLE
Type piracy

### DIFF
--- a/src/NeuralVerification.jl
+++ b/src/NeuralVerification.jl
@@ -20,7 +20,12 @@ abstract type Solver end
 # For optimization methods:
 import JuMP.MOI.OPTIMAL, JuMP.MOI.INFEASIBLE
 JuMP.Model(solver::Solver) = Model(solver.optimizer)
-JuMP.value(vars::Vector{VariableRef}) = value.(vars)
+# define a `value` function that recurses so that value(vector) and
+# value(VecOfVec) works cleanly. This is only so the code looks nice.
+value(var::JuMP.AbstractJuMPScalar) = JuMP.value(var)
+value(vars::Vector) = value.(vars)
+value(val) = val
+
 
 include("utils/activation.jl")
 include("utils/network.jl")

--- a/src/optimization/iLP.jl
+++ b/src/optimization/iLP.jl
@@ -45,7 +45,7 @@ function solve(solver::ILP, problem::Problem)
         encode_network!(model, nnet, StandardLP())
         optimize!(model)
         termination_status(model) != OPTIMAL && return AdversarialResult(:unknown)
-        x = value.(first(z))
+        x = value(first(z))
         return interpret_result(solver, x, problem.input)
     end
 
@@ -53,7 +53,7 @@ function solve(solver::ILP, problem::Problem)
     while true
         optimize!(model)
         termination_status(model) != OPTIMAL && return AdversarialResult(:unknown)
-        x = value.(first(z))
+        x = value(first(z))
         matched, index = match_activation(nnet, x, δ)
         if matched
             return interpret_result(solver, x, problem.input)

--- a/src/optimization/mipVerify.jl
+++ b/src/optimization/mipVerify.jl
@@ -43,8 +43,8 @@ function solve(solver::MIPVerify, problem::Problem)
     encode_network!(model, problem.network, BoundedMixedIntegerLP())
     o = max_disturbance!(model, first(z) - problem.input.center)
     optimize!(model)
-    if termination_status(model) == INFEASIBLE
-        return AdversarialResult(:holds)
+    if termination_status(model) == OPTIMAL
+        return AdversarialResult(:violated, value(o))
     end
-    return AdversarialResult(:violated, value(o))
+    return AdversarialResult(:holds)
 end

--- a/src/optimization/nsVerify.jl
+++ b/src/optimization/nsVerify.jl
@@ -51,7 +51,7 @@ function solve(solver::NSVerify, problem::Problem)
     optimize!(model)
 
     if termination_status(model) == OPTIMAL
-        return CounterExampleResult(:violated, value.(first(z)))
+        return CounterExampleResult(:violated, value(first(z)))
     elseif termination_status(model) == INFEASIBLE
         return CounterExampleResult(:holds)
     else

--- a/src/optimization/nsVerify.jl
+++ b/src/optimization/nsVerify.jl
@@ -52,7 +52,6 @@ function solve(solver::NSVerify, problem::Problem)
 
     if termination_status(model) == OPTIMAL
         return CounterExampleResult(:violated, value.(first(z)))
-
     elseif termination_status(model) == INFEASIBLE
         return CounterExampleResult(:holds)
     else

--- a/src/optimization/utils/objectives.jl
+++ b/src/optimization/utils/objectives.jl
@@ -24,10 +24,3 @@ end
 
 # This is the default when creating a model. Only used for explicit-ness.
 feasibility_problem!(model::Model) = nothing
-
-function linear_objective!(mode::Model, map::HPolytope, var)
-    c, d = tosimplehrep(map)
-    o = c * var - d
-    @objective(model, Min, o)
-    return o
-end

--- a/src/satisfiability/reluplex.jl
+++ b/src/satisfiability/reluplex.jl
@@ -112,7 +112,7 @@ function reluplex_step(solver::Reluplex, model::Model)
         i, j = find_relu_to_fix(ẑ, z)
 
         # In case no broken relus could be found, return the input as a counterexample
-        i == 0 && return CounterExampleResult(:violated, value.(first(ẑ)))
+        i == 0 && return CounterExampleResult(:violated, value(first(ẑ)))
 
         for repair! in (type_one_repair!, type_two_repair!)
             # Add the constraints associated with the ReLU being fixed

--- a/src/satisfiability/reluplex.jl
+++ b/src/satisfiability/reluplex.jl
@@ -111,7 +111,7 @@ function reluplex_step(solver::Reluplex, model::Model)
     if termination_status(model) == OPTIMAL
         i, j = find_relu_to_fix(ẑ, z)
 
-        # In case no broken relus could be found, return the "input" as a counterexample
+        # In case no broken relus could be found, return the input as a counterexample
         i == 0 && return CounterExampleResult(:violated, value.(first(ẑ)))
 
         for repair! in (type_one_repair!, type_two_repair!)
@@ -121,10 +121,11 @@ function reluplex_step(solver::Reluplex, model::Model)
             # Recurse with the ReLU i, j fixed to active or inactive
             result = reluplex_step(solver, model)
 
+            # Return (all the way to top level) if violated.
+            result.status == :violated && return result
+
             # Reset the model when we're done with this ReLU
             delete.(model, new_constraints)
-
-            result.status == :violated && return result
         end
     end
     return CounterExampleResult(:holds)

--- a/src/satisfiability/sherlock.jl
+++ b/src/satisfiability/sherlock.jl
@@ -72,8 +72,11 @@ function local_search(problem::Problem, x::Vector{Float64}, optimizer, type::Sym
     add_set_constraint!(model, problem.input, first(z))
     encode_network!(model, nnet, StandardLP())
 
+    # the gradient wrt to the input is a `1xn` matrix,
+    # because the output is 1-d. Therefore o[1] is the
+    # only entry in g*z₀
     gradient = get_gradient(nnet, x)
-    o = gradient*first(z)
+    o = gradient * first(z)
     index = ifelse(type == :max, 1, -1)
     @objective(model, Max, index * o[1])
     optimize!(model)

--- a/src/satisfiability/sherlock.jl
+++ b/src/satisfiability/sherlock.jl
@@ -73,9 +73,9 @@ function local_search(problem::Problem, x::Vector{Float64}, optimizer, type::Sym
     encode_network!(model, nnet, StandardLP())
 
     gradient = get_gradient(nnet, x)
-    o = gradient'*first(z)
+    o = gradient*first(z)
     index = ifelse(type == :max, 1, -1)
-    @objective(model, Max, index * o)
+    @objective(model, Max, index * o[1])
     optimize!(model)
 
     x_new = value(first(z))


### PR DESCRIPTION
Gets rid of a case of terrible type piracy we've had floating around since the beginning. 
In the process replaces all `value.()` calls with `value()`, which is probably cleaner style for our purposes.

Also supercedes #167, which brings in the fix_opt (#72) changes that are still relevant.