### PR TITLE
updated toml with version number

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,6 @@
 name = "NeuralVerification"
 uuid = "146f25fa-00e7-11e9-3ae5-fdbac6e12fa7"
+version = "0.1.0"
 
 [deps]
 CDDLib = "3391f64e-dcde-5f30-b752-e11513730f60"


### PR DESCRIPTION
Added a version number to the toml. It seems like this is needed for other packages to include it as a dependency, otherwise when trying to dev a package that depends on NeuralVerification.jl you get a message like 

ERROR: Unsatisfiable requirements detected for package NeuralVerification [146f25fa]:
 NeuralVerification [146f25fa] log:
 ├─NeuralVerification [146f25fa] has no known versions!
 └─restricted to versions * by NeuralPriorityOptimizer [7e1232c4] — no versions left
   └─NeuralPriorityOptimizer [7e1232c4] log:
     ├─possible versions are: 0.1.0 or uninstalled
     └─NeuralPriorityOptimizer [7e1232c4] is fixed to version 0.1.0

(credits to Mykel for finding this issue).