### PR TITLE
fix to write_nnet

### DIFF
--- a/src/utils/util.jl
+++ b/src/utils/util.jl
@@ -73,8 +73,8 @@ The NNet format has a particular header containing information about the network
 """
 function print_header(file::IOStream, network; header_text="")
    println(file, to_comment(header_text))
-   layer_sizes = [size(layer.weights, 1) for layer in network.layers] # doesn't include the output layer
-   pushfirst!(layer_sizes, size(network.layers[end].weights, 1)) # add the output layer
+   layer_sizes = [size(layer.weights, 1) for layer in network.layers] # doesn't include the input layer
+   pushfirst!(layer_sizes, size(network.layers[1].weights, 1)) # add the input layer
 
    # num layers, num inputs, num outputs, max layer size
    num_layers = length(network.layers)


### PR DESCRIPTION
There was a small bug in write_nnet where the last layer size was pushed onto the front of the layer_sizes instead of the first layer_size. Here is a one-line change to address that (described in issue #193.  