### PR TITLE
Adding constraints so that binary variables reflect correct activation status

### DIFF
--- a/src/optimization/utils/constraints.jl
+++ b/src/optimization/utils/constraints.jl
@@ -132,7 +132,6 @@ function encode_relu(::SlackLP, model, ẑᵢⱼ, zᵢⱼ, δᵢⱼ, sᵢⱼ)
     if δᵢⱼ
         @constraint(model, zᵢⱼ == ẑᵢⱼ + sᵢⱼ)
         @constraint(model, ẑᵢⱼ + sᵢⱼ >= 0.0)
-        # how to encode necessary constraint on δᵢⱼ here?
     else
         @constraint(model, zᵢⱼ == sᵢⱼ)
         @constraint(model, ẑᵢⱼ <= sᵢⱼ)
@@ -163,10 +162,8 @@ end
 function encode_relu(::TriangularRelaxedLP, model, ẑᵢⱼ, zᵢⱼ, l̂ᵢⱼ, ûᵢⱼ)
     if l̂ᵢⱼ > 0.0
         @constraint(model, zᵢⱼ == ẑᵢⱼ)
-        @constraint(model, δᵢⱼ == 1)
     elseif ûᵢⱼ < 0.0
         @constraint(model, zᵢⱼ == 0.0)
-        @constraint(model, δᵢⱼ == 0)
     else
         @constraints(model, begin
                                 zᵢⱼ >= 0.0
@@ -177,18 +174,16 @@ function encode_relu(::TriangularRelaxedLP, model, ẑᵢⱼ, zᵢⱼ, l̂ᵢⱼ
 end
 
 function encode_relu(::LinearRelaxedLP, model, ẑᵢⱼ, zᵢⱼ, δᵢⱼ)
-    @constraint(model, zᵢⱼ == (δᵢⱼ ? ẑᵢⱼ : 0.0)) # what does this mean? how can you use ? in a constraint?
+    @constraint(model, zᵢⱼ == (δᵢⱼ ? ẑᵢⱼ : 0.0)) # in LinearRelaxedLP δᵢⱼ is a constant not a variable
 end
 
 function encode_relu(::StandardLP, model, ẑᵢⱼ, zᵢⱼ, δᵢⱼ)
-    if δᵢⱼ
+    if δᵢⱼ # in StandardLP δᵢⱼ is a constant, not a variable
         @constraint(model, ẑᵢⱼ >= 0.0)
         @constraint(model, zᵢⱼ == ẑᵢⱼ)
-        @constraint(model, δᵢⱼ == 1)
     else
         @constraint(model, ẑᵢⱼ <= 0.0)
         @constraint(model, zᵢⱼ == 0.0)
-        @constraint(model, δᵢⱼ == 0)
     end
 end
 

--- a/src/optimization/utils/constraints.jl
+++ b/src/optimization/utils/constraints.jl
@@ -106,7 +106,6 @@ end
 
 # need to fix δᵢⱼ for BoundedMixedIntegerLP and possibly other types 
 function encode_layer!(::BoundedMixedIntegerLP, model::Model, layer::Layer{Id}, ẑᵢ, zᵢ, δᵢ, args...)
-    println("Using new case! δᵢ = $(δᵢ)")
     @constraint(model, zᵢ .== ẑᵢ)
     @constraint(model, δᵢ .== 1)
     return nothing

--- a/src/optimization/utils/constraints.jl
+++ b/src/optimization/utils/constraints.jl
@@ -89,6 +89,7 @@ function encode_layer!(::AbstractLinearProgram, model::Model, layer::Layer{Id}, 
     nothing
 end
 
+# All ReLU layers pass through this
 function encode_layer!(LP::AbstractLinearProgram, model::Model, layer::Layer{ReLU}, args...)
     encode_relu.(LP, model, args...)
     nothing
@@ -104,10 +105,10 @@ function encode_layer!(SLP::SlackLP, model::Model, layer::Layer{Id}, ẑᵢ, z�
 end
 
 # need to fix δᵢⱼ for BoundedMixedIntegerLP and possibly other types 
-function encode_layer!(::BoundedMixedIntegerLP, model::Model, layer::Layer{Id}, ẑᵢ, zᵢ, δᵢⱼ, args...)
-    println("Using new case!")
+function encode_layer!(::BoundedMixedIntegerLP, model::Model, layer::Layer{Id}, ẑᵢ, zᵢ, δᵢ, args...)
+    println("Using new case! δᵢⱼ = $(δᵢⱼ)")
     @constraint(model, zᵢ .== ẑᵢ)
-    @constraint(model, δᵢⱼ == 1)
+    @constraint(model, δᵢ .== 1)
     return nothing
 end
 

--- a/src/optimization/utils/constraints.jl
+++ b/src/optimization/utils/constraints.jl
@@ -106,7 +106,7 @@ end
 
 # need to fix δᵢⱼ for BoundedMixedIntegerLP and possibly other types 
 function encode_layer!(::BoundedMixedIntegerLP, model::Model, layer::Layer{Id}, ẑᵢ, zᵢ, δᵢ, args...)
-    println("Using new case! δᵢⱼ = $(δᵢⱼ)")
+    println("Using new case! δᵢ = $(δᵢ)")
     @constraint(model, zᵢ .== ẑᵢ)
     @constraint(model, δᵢ .== 1)
     return nothing

--- a/src/optimization/utils/constraints.jl
+++ b/src/optimization/utils/constraints.jl
@@ -86,7 +86,6 @@ end
 # For an Id Layer, any encoding type defaults to this:
 function encode_layer!(::AbstractLinearProgram, model::Model, layer::Layer{Id}, ẑᵢ, zᵢ, args...)
     @constraint(model, zᵢ .== ẑᵢ)
-    # how do we access δᵢⱼ variable so that it can be properly constrained to 1?
     nothing
 end
 
@@ -104,6 +103,13 @@ function encode_layer!(SLP::SlackLP, model::Model, layer::Layer{Id}, ẑᵢ, z�
     return nothing
 end
 
+# need to fix δᵢⱼ for BoundedMixedIntegerLP and possibly other types 
+function encode_layer!(::BoundedMixedIntegerLP, model::Model, layer::Layer{Id}, ẑᵢ, zᵢ, δᵢⱼ, args...)
+    println("Using new case!")
+    @constraint(model, zᵢ .== ẑᵢ)
+    @constraint(model, δᵢⱼ == 1)
+    return nothing
+end
 
 function encode_ij(LP, model, i, j)
     # where is this function used? Needs documentation.


### PR DESCRIPTION
Upon inspection of optimization/utils/constraints.jl it appears that the binary variables encoding the activation status of relus in the network are not properly constrained. 
This is not a problem if you are not reasoning about the values of the binary variables, but I am using NeuralVerification.jl for an application where I am doing just this.

For example, if the lower bound of a relu is >0 the code previously just has:
```
function encode_relu(::BoundedMixedIntegerLP, model, ẑᵢⱼ, zᵢⱼ, δᵢⱼ, l̂ᵢⱼ, ûᵢⱼ)
    if l̂ᵢⱼ >= 0.0
        @constraint(model, zᵢⱼ == ẑᵢⱼ)
...
```
And the corresponding δᵢⱼ  is free to assume either 0 or 1. 
To be most precise, δᵢⱼ should be fixed to 1 as this relu will always be active.

I have implemented these changes for the cases that I could easily understand in my own fork of this repo: 
https://github.com/chelseas/NeuralVerification.jl/tree/fix_binary

I would appreciate some assistance in making any necessary remaining changes. For example, I am using the BoundedMixedIntegerLP() type and so I have made changes focused on this and similar problem types. I'm not sure exactly how to implement this change for example, for SlackLP. 

Additionally, I'm not sure how to make these changes for the case of a layer with Identity (Id) activation. At the current moment in my own implementation, I use the init_vars() function to create the binary variables, which creates them for each layer, even if that layer were to have an identity activation. If this is going to continue to be the case, then the encode_layer for Identity activation should be changed:
```
# For an Id Layer, any encoding type defaults to this:
function encode_layer!(::AbstractLinearProgram, model::Model, layer::Layer{Id}, ẑᵢ, zᵢ, args...)
    @constraint(model, zᵢ .== ẑᵢ)
    # how do we access δᵢⱼ variable so that it can be properly constrained to 1?
    nothing
end
```
so that the corresponding binary variables is fixed to 1. However I'm not sure if it's okay to change the function signature where there is args... currently, so to explicitly require delta_ij. (Also not super familiar with the use of args... in Julia).