### PR TITLE
Update util.jl

### DIFF
--- a/src/utils/util.jl
+++ b/src/utils/util.jl
@@ -74,7 +74,7 @@ The NNet format has a particular header containing information about the network
 function print_header(file::IOStream, network; header_text="")
    println(file, to_comment(header_text))
    layer_sizes = [size(layer.weights, 1) for layer in network.layers] # doesn't include the input layer
-   pushfirst!(layer_sizes, size(network.layers[1].weights, 1)) # add the input layer
+   pushfirst!(layer_sizes, size(network.layers[1].weights, 2)) # add the input layer
 
    # num layers, num inputs, num outputs, max layer size
    num_layers = length(network.layers)


### PR DESCRIPTION
This fixes a bug in write_nnet  so that the input dimension is read correctly.
Due to the deprecation of the input and output bounds in the nnet header ( in general usage that I have seen)  I don't think this has caused bugs, but it is confusing because the input size is not printed correctly in the header.  I personally do look at the header for basic information about the network like input and output sizes and number of layers and I would like that to be correct.