### PR TITLE
slight update in documentation to point to test instead of example folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ solver = BaB()
 ```
 ### Set up the problem
 ```julia
-nnet = read_nnet("examples/networks/small_nnet.nnet")
+nnet = read_nnet("test/networks/small_nnet.nnet")
 input_set  = Hyperrectangle(low = [-1.0], high = [1.0])
 output_set = Hyperrectangle(low = [-1.0], high = [70.0])
 problem = Problem(nnet, input_set, output_set)


### PR DESCRIPTION
Now there is no example folder, the line

`nnet = read_nnet("examples/networks/small_nnet.nnet")`

may be misleading if people are trying to find the network file. So I just updated it to "test/networks" instead of "examples/networks".
